### PR TITLE
Revert "refactor: replace spec style vim.validate"

### DIFF
--- a/lua/cppguard.lua
+++ b/lua/cppguard.lua
@@ -62,9 +62,17 @@ function M.guard_string(opts)
     opts = opts or {}
     opts.naming_method = opts.naming_method or "google"
 
-    vim.validate("naming_method", opts.naming_method, function(v)
-        return vim.tbl_contains({ "google" }, v)
-    end, false, "google")
+    vim.validate {
+        naming_method = {
+            opts.naming_method,
+            function()
+                return vim.tbl_contains({
+                    "google",
+                }, opts.naming_method)
+            end,
+            "google",
+        },
+    }
 
     if opts.naming_method == "google" then
         local current_path = vim.fs.normalize(vim.api.nvim_buf_get_name(0))


### PR DESCRIPTION
Reverts pogyomo/cppguard.nvim#7
nvim-0.10 only support spec style vim.validate